### PR TITLE
Change VTO Launch command to use Python 3.7

### DIFF
--- a/charts/virtual-try-on/Chart.yaml
+++ b/charts/virtual-try-on/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/virtual-try-on/templates/deployment.yaml
+++ b/charts/virtual-try-on/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
-            - python3.9
+            - python3.7
             - server_http.py
           env:
             - name: SERVICE_PORT


### PR DESCRIPTION
new VTO requires Python 3.7 instead of PYthong3.9
Changed the launch command for the container