### PR TITLE
Added GPU resource to support VTO

### DIFF
--- a/charts/virtual-try-on/values.yaml
+++ b/charts/virtual-try-on/values.yaml
@@ -51,17 +51,9 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources:
+  limits:
+    nvidia.com/gpu: 1
 
 env:
   SCENE_HOST: scene-engine


### PR DESCRIPTION
virtual-try-on Helm Chart values added 
resources:
  limits:
    nvidia.com/gpu: 1
to use GPU for VTO