### PR TITLE
Change que concurrency to 2

### DIFF
--- a/charts/render/Chart.yaml
+++ b/charts/render/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/render/templates/render-worker.yaml
+++ b/charts/render/templates/render-worker.yaml
@@ -36,7 +36,7 @@ spec:
         - containerPort: 8000
         - containerPort: 80
          # protocol: TCP
-        command: ["celery",  "-A", "render_frame", "worker", "-Ofair", "--task-events", "--pool", "threads", "-c", "4", "-Q", "rendering_queue"]
+        command: ["celery",  "-A", "render_frame", "worker", "-Ofair", "--task-events", "--pool", "threads", "-c", "2", "-Q", "rendering_queue"]
         env:  
         - name: SERVICE_PORT
           value: {{ .Values.service.port | quote }} 


### PR DESCRIPTION
Rendering was running out of memory. We initially tested on the G5. The G3 can't support 4 simultaneous renders 