### PR TITLE
update sdf generation worker version

### DIFF
--- a/charts/sdf-generation/Chart.yaml
+++ b/charts/sdf-generation/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sdf-generation/templates/sdf-generation.yaml
+++ b/charts/sdf-generation/templates/sdf-generation.yaml
@@ -32,7 +32,7 @@ spec:
       - name: {{ .Chart.Name }}
         image:  "{{ .Values.image.repository }}:{{ .Values.image.tag }}" 
         imagePullPolicy:  {{ .Values.image.pullPolicy }}
-        command: ["/app/sdf-worker",  "api"]
+        command: ["celery",  "-A", "sdf_worker", "worker",  "--prefetch-multiplier", "1", "--task-events", "--pool", "threads", "-c", "3", "-Q", "sdf_creation_queue"]
         env:  
         - name: SERVICE_PORT
           value: {{ .Values.service.port | quote }} 

--- a/charts/sdf-generation/values.yaml
+++ b/charts/sdf-generation/values.yaml
@@ -4,7 +4,7 @@ image:
   repository: ghcr.io/thefittingroom/sdf-generation-worker
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 0.0.1
+  tag: de22a27
 
 imagePullSecrets:
   - name: docker-registry
@@ -53,13 +53,11 @@ ingress:
 #    nvidia.com/gpu: 1
 
 env:
-  GENERATOR_PATH: /app/sdf_generator
-  GENERATOR_RESOLUTION: 0.01
-  GENERATOR_TIMEOUT_SECONDS: 5
   REDIS_HOST: redis.dev.thefittingroom.xyz:6379
-  REDIS_QUEUE: sdf_creation_task
-  REDIS_TASK: create_sdf
-  S3_AVATAR_BUCKET: avatar_creation_dev
+  REGION: us-west-2
+  AVATAR_BUCKET: avatar-creation-dev
+  GENERATOR_PATH: /app/sdf_generator
+  RESOLUTION: 0.01
   LOGER_LEVEL: INFO
   CELERY_WORKER_PREFETCH_MULTIPLIER: "1"
   CELERY_WORKER_SEND_TASK_EVENTS: "true"


### PR DESCRIPTION
Updates the helm-chart to support the rewritten sdf-generation-worker using python instead of go for the service worker.