### PR TITLE
Add access to the redis.host environment variable to the tfr-backend cronjob template

### DIFF
--- a/charts/tfr-backend/templates/cronjob.yaml
+++ b/charts/tfr-backend/templates/cronjob.yaml
@@ -43,6 +43,9 @@ spec:
                 - job
               args: {{ $jobSettings.command }}
               workingDir: /tfr-backend
+              env:
+                - name: REDIS_URL
+                  value: "redis://{{ .Values.redis.host }}"
               {{- range $jobSettings.envFrom }}
               envFrom:
                 {{- if .configMapRef }}


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/TheFittingRoom/helm-charts/pull/75?shareId=58045d4b-22d2-493b-8b8c-1a2979350b43).